### PR TITLE
feature/AWS-42-Replace-block-with-perm-time-shadow-bans

### DIFF
--- a/frontend/src/app/core/components/input-field/input-field.html
+++ b/frontend/src/app/core/components/input-field/input-field.html
@@ -34,6 +34,23 @@
           <label [for]="inputId">{{ label }}</label>
         }
       </p-floatlabel>
+    } @else if (type === "select" && control) {
+      <p-floatlabel [variant]="label ? 'in' : 'on'">
+        <p-select
+          [inputId]="inputId"
+          [formControl]="control"
+          [options]="options"
+          optionLabel="label"
+          optionValue="value"
+          (onBlur)="onBlur()"
+          [class.ng-invalid]="isInvalid"
+          [class.p-filled]="control.value != null && control.value !== ''"
+          class="w-full"
+        />
+        @if (label) {
+          <label [for]="inputId">{{ label }}</label>
+        }
+      </p-floatlabel>
     } @else if (type === "textarea") {
       <p-floatlabel [variant]="label ? 'in' : 'on'">
         <textarea

--- a/frontend/src/app/core/components/input-field/input-field.ts
+++ b/frontend/src/app/core/components/input-field/input-field.ts
@@ -17,11 +17,12 @@ import { DatePickerModule } from 'primeng/datepicker';
 import { FloatLabelModule } from 'primeng/floatlabel';
 import { InputTextModule } from 'primeng/inputtext';
 import { PasswordModule } from 'primeng/password';
+import { SelectModule } from 'primeng/select';
 import { TextareaModule } from 'primeng/textarea';
 import { InputIcon } from 'primeng/inputicon';
 import { IconField } from 'primeng/iconfield';
 import { TranslateModule } from '@ngx-translate/core';
-import { ValidationMessage } from '../../models';
+import { ValidationMessage, SelectOption } from '../../models';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 @Component({
@@ -33,6 +34,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
     PasswordModule,
     TextareaModule,
     DatePickerModule,
+    SelectModule,
     IconField,
     InputIcon,
     TranslateModule,
@@ -49,8 +51,9 @@ export class InputField implements ControlValueAccessor, OnInit {
   @Input({ required: true }) inputId!: string;
   @Input() label = '';
   @Input() placeholder = '';
-  @Input() type: 'text' | 'email' | 'password' | 'textarea' | 'datepicker' =
+  @Input() type: 'text' | 'email' | 'password' | 'textarea' | 'datepicker' | 'select' =
     'text';
+  @Input() options: SelectOption[] = [];
   @Input() dateFormat = 'dd/mm/yy';
   @Input() showDateIcon = true;
   @Input() validationMessages: ValidationMessage[] = [];

--- a/frontend/src/app/core/components/table/components/table-cell/table-cell.ts
+++ b/frontend/src/app/core/components/table/components/table-cell/table-cell.ts
@@ -1,7 +1,7 @@
 import { DatePipe } from '@angular/common';
 import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
 import { TagModule } from 'primeng/tag';
-import { TableColumnType } from '../../../../models';
+import { TableColumnType, UserBanType } from '../../../../models';
 import { TranslateModule } from '@ngx-translate/core';
 
 @Component({
@@ -19,17 +19,49 @@ export class TableCell {
   readonly TableColumnType = TableColumnType;
 
   get tagValue(): string {
-    if (this.columnKey === 'confirmed')
+    if (this.columnKey === 'confirmed') {
       return this.value ? 'profile.confirmed' : 'profile.notConfirmed';
-    if (this.columnKey === 'blocked')
-      return this.value ? 'profile.blocked' : 'profile.active';
+    }
+    if (this.columnKey === 'banType') {
+      return this.getBanTypeLabel(this.value as string);
+    }
     return '';
   }
 
-  get tagSeverity(): 'success' | 'danger' {
-    if (this.columnKey === 'confirmed')
+  get tagSeverity(): 'success' | 'danger' | 'warn' | 'info' {
+    if (this.columnKey === 'confirmed') {
       return this.value ? 'success' : 'danger';
-    if (this.columnKey === 'blocked') return this.value ? 'danger' : 'success';
+    }
+    if (this.columnKey === 'banType') {
+      return this.getBanTypeSeverity(this.value as string);
+    }
     return 'success';
+  }
+
+  private getBanTypeLabel(banType: string | null | undefined): string {
+    switch (banType) {
+      case UserBanType.SHADOW:
+        return 'users.ban.type.shadow';
+      case UserBanType.TIME:
+        return 'users.ban.type.time';
+      case UserBanType.PERM:
+        return 'users.ban.type.perm';
+      default:
+        return 'users.ban.type.active';
+    }
+  }
+
+  private getBanTypeSeverity(
+    banType: string | null | undefined,
+  ): 'success' | 'danger' | 'warn' | 'info' {
+    switch (banType) {
+      case UserBanType.SHADOW:
+        return 'warn';
+      case UserBanType.TIME:
+      case UserBanType.PERM:
+        return 'danger';
+      default:
+        return 'success';
+    }
   }
 }

--- a/frontend/src/app/core/models/auth/index.ts
+++ b/frontend/src/app/core/models/auth/index.ts
@@ -6,3 +6,5 @@ export * from './password-reset-request.model';
 export * from './password-reset.model';
 export * from './user-role.model';
 export * from './user-role-type.enum';
+export * from './user-ban-type.enum';
+export * from './user-ban-update.model';

--- a/frontend/src/app/core/models/auth/user-ban-type.enum.ts
+++ b/frontend/src/app/core/models/auth/user-ban-type.enum.ts
@@ -1,0 +1,5 @@
+export enum UserBanType {
+  SHADOW = 'shadow',
+  TIME = 'time',
+  PERM = 'perm',
+}

--- a/frontend/src/app/core/models/auth/user-ban-update.model.ts
+++ b/frontend/src/app/core/models/auth/user-ban-update.model.ts
@@ -1,0 +1,6 @@
+import { UserBanType } from './user-ban-type.enum';
+
+export interface UserBanUpdate {
+  banType: UserBanType | null;
+  banExpiresAt?: string | null;
+}

--- a/frontend/src/app/core/models/auth/user.model.ts
+++ b/frontend/src/app/core/models/auth/user.model.ts
@@ -1,5 +1,6 @@
 import { Media } from '../media.type';
 import { UserRole } from './user-role.model';
+import { UserBanType } from './user-ban-type.enum';
 
 export interface User {
   id: number;
@@ -9,6 +10,8 @@ export interface User {
   provider: string;
   confirmed: boolean;
   blocked: boolean;
+  banType?: UserBanType | null;
+  banExpiresAt?: string | null;
   role: UserRole;
   firstName?: string;
   lastName?: string;

--- a/frontend/src/app/core/models/index.ts
+++ b/frontend/src/app/core/models/index.ts
@@ -1,4 +1,6 @@
 export * from './auth/user.model';
+export * from './auth/user-ban-type.enum';
+export * from './auth/user-ban-update.model';
 export * from './auth/login-credentials.model';
 export * from './auth/auth-response.model';
 export * from './auth/register-credentials.model';
@@ -6,6 +8,7 @@ export * from './auth/password-reset-request.model';
 export * from './auth/password-reset.model';
 export * from './paginated.model';
 export * from './validation-messages.type';
+export * from './select-option.type';
 export * from './table-config.type';
 export * from './table-load-params.type';
 export * from './table-column.type';

--- a/frontend/src/app/core/models/select-option.type.ts
+++ b/frontend/src/app/core/models/select-option.type.ts
@@ -1,0 +1,4 @@
+export interface SelectOption<T extends string | number = string | number> {
+  label: string;
+  value: T;
+}

--- a/frontend/src/app/core/pages/profile/profile.html
+++ b/frontend/src/app/core/pages/profile/profile.html
@@ -82,17 +82,29 @@
         "
       />
       <app-data-row
-        [label]="'profile.account' | translate"
+        [label]="'profile.banStatus' | translate"
         [value]="
-          (userData.blocked ? 'profile.blocked' : 'profile.active') | translate
+          ('users.ban.type.' + (userData.banType || 'active')) | translate
         "
-        [icon]="userData.blocked ? 'pi pi-ban' : 'pi pi-check'"
+        [icon]="
+          !userData.banType
+            ? 'pi pi-check'
+            : 'pi pi-ban'
+        "
         [valueClass]="
-          userData.blocked
-            ? 'text-red-600 font-medium'
-            : 'text-green-600 font-medium'
+          !userData.banType
+            ? 'text-green-600 font-medium'
+            : userData.banType === 'shadow'
+              ? 'text-amber-600 font-medium'
+              : 'text-red-600 font-medium'
         "
       />
+      @if (userData.banType === 'time' && userData.banExpiresAt) {
+        <app-data-row
+          [label]="'users.ban.expiresAt' | translate"
+          [value]="(userData.banExpiresAt | date: 'dd/MM/yyyy HH:mm') || '-'"
+        />
+      }
       <app-data-row
         [label]="'profile.role' | translate"
         [value]="userData.role.name || '-'"

--- a/frontend/src/app/core/pages/users/components/apply-ban-dialog/apply-ban-dialog.html
+++ b/frontend/src/app/core/pages/users/components/apply-ban-dialog/apply-ban-dialog.html
@@ -1,0 +1,57 @@
+<app-dialog
+  [visible]="visible()"
+  (visibleChange)="visible.set($event)"
+  [title]="'users.ban.title' | translate"
+  icon="pi pi-ban"
+  styleClass="w-full sm:w-[500px]"
+>
+  @if (selectedUser(); as user) {
+    <p class="text-color mb-4">
+      {{ "users.ban.targetUser" | translate }}:
+      <strong>{{ user.username }}</strong>
+    </p>
+  }
+
+  <form
+    [formGroup]="banForm"
+    (ngSubmit)="onApply()"
+    class="w-full flex flex-col gap-5"
+  >
+    <app-input-field
+      [label]="'users.ban.typeLabel' | translate"
+      inputId="banType"
+      formControlName="banType"
+      type="select"
+      labelWidth="10rem"
+      [options]="banTypeOptions"
+    />
+
+    @if (banForm.controls.banType.value === UserBanType.TIME) {
+      <app-input-field
+        [label]="'users.ban.durationLabel' | translate"
+        inputId="banDuration"
+        formControlName="durationMinutes"
+        type="select"
+        labelWidth="10rem"
+        [options]="durationOptions"
+      />
+    }
+  </form>
+
+  <div dialogFooter class="w-full flex items-center justify-end gap-2 mt-6">
+    <p-button
+      type="button"
+      [label]="'common.cancel' | translate"
+      [outlined]="true"
+      (click)="visible.set(false)"
+      styleClass="w-32"
+    />
+    <p-button
+      type="button"
+      [label]="'users.ban.apply' | translate"
+      (click)="onApply()"
+      styleClass="w-32"
+      [disabled]="banForm.invalid"
+    />
+  </div>
+</app-dialog>

--- a/frontend/src/app/core/pages/users/components/apply-ban-dialog/apply-ban-dialog.ts
+++ b/frontend/src/app/core/pages/users/components/apply-ban-dialog/apply-ban-dialog.ts
@@ -1,0 +1,127 @@
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  DestroyRef,
+  inject,
+  OnInit,
+  signal,
+} from '@angular/core';
+import {
+  FormControl,
+  FormGroup,
+  ReactiveFormsModule,
+  Validators,
+} from '@angular/forms';
+import { ButtonModule } from 'primeng/button';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
+import { finalize } from 'rxjs';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { Dialog, InputField } from '../../../../components';
+import { User, UserBanType, SelectOption } from '../../../../models';
+import { UserApiService } from '../../../../services/user-api-service';
+import {
+  BAN_DURATION_PRESETS,
+  BAN_TYPE_OPTIONS,
+} from '../../constants/ban-options.const';
+
+@Component({
+  selector: 'app-apply-ban-dialog',
+  imports: [
+    Dialog,
+    ButtonModule,
+    ReactiveFormsModule,
+    InputField,
+    TranslateModule,
+  ],
+  templateUrl: './apply-ban-dialog.html',
+  styleUrl: './apply-ban-dialog.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ApplyBanDialog implements OnInit {
+  private userApiService = inject(UserApiService);
+  private destroyRef = inject(DestroyRef);
+  private translate = inject(TranslateService);
+  private cdr = inject(ChangeDetectorRef);
+
+  visible = signal(false);
+  selectedUser = signal<User | null>(null);
+  banTypeOptions: SelectOption<UserBanType>[] = [];
+  durationOptions: SelectOption<number>[] = [];
+
+  banForm!: FormGroup<{
+    banType: FormControl<UserBanType>;
+    durationMinutes: FormControl<number>;
+  }>;
+
+  readonly UserBanType = UserBanType;
+
+  ngOnInit(): void {
+    this.initForm();
+  }
+
+  private initForm(): void {
+    this.banForm = new FormGroup({
+      banType: new FormControl<UserBanType>(UserBanType.PERM, {
+        nonNullable: true,
+        validators: Validators.required,
+      }),
+      durationMinutes: new FormControl(5, {
+        nonNullable: true,
+        validators: Validators.required,
+      }),
+    });
+
+    this.banForm.controls.banType.valueChanges
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(() => this.cdr.markForCheck());
+  }
+
+  showDialog(user: User): void {
+    this.selectedUser.set(user);
+    this.banTypeOptions = BAN_TYPE_OPTIONS.map((option) => ({
+      value: option.value,
+      label: this.translate.instant(option.label),
+    }));
+    this.durationOptions = BAN_DURATION_PRESETS.map((option) => ({
+      value: option.minutes,
+      label: this.translate.instant(option.label),
+    }));
+    this.banForm.reset({
+      banType: UserBanType.PERM,
+      durationMinutes: 5,
+    });
+    this.visible.set(true);
+  }
+
+  onApply(): void {
+    if (this.banForm.invalid) {
+      return;
+    }
+
+    const user = this.selectedUser();
+    if (!user) {
+      return;
+    }
+
+    const { banType, durationMinutes } = this.banForm.getRawValue();
+    const payload = {
+      banType,
+      ...(banType === UserBanType.TIME
+        ? {
+            banExpiresAt: new Date(
+              Date.now() + durationMinutes * 60 * 1000,
+            ).toISOString(),
+          }
+        : { banExpiresAt: null }),
+    };
+
+    this.userApiService
+      .updateUserBan(user.id.toString(), payload)
+      .pipe(
+        takeUntilDestroyed(this.destroyRef),
+        finalize(() => this.visible.set(false)),
+      )
+      .subscribe();
+  }
+}

--- a/frontend/src/app/core/pages/users/components/details-dialog/details-dialog.html
+++ b/frontend/src/app/core/pages/users/components/details-dialog/details-dialog.html
@@ -54,15 +54,30 @@
             userData.confirmed ? 'text-green-600' : 'text-amber-600'
           "
         />
+      <app-data-row
+        [label]="'profile.banStatus' | translate"
+        [value]="
+          ('users.ban.type.' + (userData.banType || 'active')) | translate
+        "
+        [icon]="
+          !userData.banType
+            ? 'pi pi-check'
+            : 'pi pi-ban'
+        "
+        [valueClass]="
+          !userData.banType
+            ? 'text-green-600'
+            : userData.banType === 'shadow'
+              ? 'text-amber-600'
+              : 'text-red-600'
+        "
+      />
+      @if (userData.banType === 'time' && userData.banExpiresAt) {
         <app-data-row
-          [label]="'profile.account' | translate"
-          [value]="
-            (userData.blocked ? 'profile.blocked' : 'profile.active')
-              | translate
-          "
-          [icon]="userData.blocked ? 'pi pi-ban' : 'pi pi-check'"
-          [valueClass]="userData.blocked ? 'text-red-600' : 'text-green-600'"
+          [label]="'users.ban.expiresAt' | translate"
+          [value]="(userData.banExpiresAt | date: 'dd/MM/yyyy HH:mm') || '-'"
         />
+      }
         <app-data-row
           [label]="'profile.aboutMe' | translate"
           [value]="userData.aboutMe || '-'"

--- a/frontend/src/app/core/pages/users/components/details-dialog/details-dialog.ts
+++ b/frontend/src/app/core/pages/users/components/details-dialog/details-dialog.ts
@@ -1,3 +1,4 @@
+import { DatePipe } from '@angular/common';
 import {
   ChangeDetectionStrategy,
   Component,
@@ -15,7 +16,7 @@ import { ButtonModule } from 'primeng/button';
 
 @Component({
   selector: 'app-details-dialog',
-  imports: [Dialog, Spinner, ButtonModule, DataRow, Avatar, TranslateModule],
+  imports: [Dialog, Spinner, ButtonModule, DataRow, Avatar, TranslateModule, DatePipe],
   templateUrl: './details-dialog.html',
   styleUrl: './details-dialog.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/frontend/src/app/core/pages/users/components/index.ts
+++ b/frontend/src/app/core/pages/users/components/index.ts
@@ -1,1 +1,2 @@
 export * from './details-dialog/details-dialog';
+export * from './apply-ban-dialog/apply-ban-dialog';

--- a/frontend/src/app/core/pages/users/constants/ban-options.const.ts
+++ b/frontend/src/app/core/pages/users/constants/ban-options.const.ts
@@ -1,0 +1,14 @@
+import { UserBanType } from '../../../models';
+
+export const BAN_TYPE_OPTIONS = [
+  { label: 'users.ban.type.perm', value: UserBanType.PERM },
+  { label: 'users.ban.type.time', value: UserBanType.TIME },
+  { label: 'users.ban.type.shadow', value: UserBanType.SHADOW },
+];
+
+export const BAN_DURATION_PRESETS = [
+  { label: 'users.ban.duration.5m', minutes: 5 },
+  { label: 'users.ban.duration.1h', minutes: 60 },
+  { label: 'users.ban.duration.7d', minutes: 60 * 24 * 7 },
+  { label: 'users.ban.duration.30d', minutes: 60 * 24 * 30 },
+];

--- a/frontend/src/app/core/pages/users/constants/users-table-config.const.ts
+++ b/frontend/src/app/core/pages/users/constants/users-table-config.const.ts
@@ -28,9 +28,14 @@ export const USERS_TABLE_CONFIG: TableConfig = {
       type: TableColumnType.STATUS_TAG,
     },
     {
-      key: 'blocked',
-      label: 'users.blocked',
+      key: 'banType',
+      label: 'users.ban.status',
       type: TableColumnType.STATUS_TAG,
+    },
+    {
+      key: 'banExpiresAt',
+      label: 'users.ban.expiresAt',
+      type: TableColumnType.DATE,
     },
     {
       key: 'createdAt',

--- a/frontend/src/app/core/pages/users/users.html
+++ b/frontend/src/app/core/pages/users/users.html
@@ -10,3 +10,4 @@
 />
 
 <app-details-dialog #detailsDialog></app-details-dialog>
+<app-apply-ban-dialog #applyBanDialog></app-apply-ban-dialog>

--- a/frontend/src/app/core/pages/users/users.ts
+++ b/frontend/src/app/core/pages/users/users.ts
@@ -12,7 +12,7 @@ import { UserApiService } from '../../services/user-api-service';
 import { TableModule } from 'primeng/table';
 import { User, RowActionItem, TableLoadParams } from '../../models';
 import { TagModule } from 'primeng/tag';
-import { DetailsDialog } from './components';
+import { ApplyBanDialog, DetailsDialog } from './components';
 import { Table } from '../../components';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { TranslateService } from '@ngx-translate/core';
@@ -22,13 +22,14 @@ import { PageTitle } from '../../constants';
 
 @Component({
   selector: 'app-users',
-  imports: [TableModule, TagModule, Table, DetailsDialog],
+  imports: [TableModule, TagModule, Table, DetailsDialog, ApplyBanDialog],
   templateUrl: './users.html',
   styleUrl: './users.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class Users implements OnInit {
   @ViewChild(DetailsDialog) detailsDialog!: DetailsDialog;
+  @ViewChild(ApplyBanDialog) applyBanDialog!: ApplyBanDialog;
 
   private userService = inject(UserApiService);
   private userStore = inject(UserStore);
@@ -55,18 +56,19 @@ export class Users implements OnInit {
   }
 
   rowActions(user: User): RowActionItem[] {
+    const hasBan = !!user.banType;
+
     return [
       {
-        label: this.translate.instant('users.block'),
-        icon: 'pi pi-lock',
-        disabled: user.blocked,
-        actionId: 'block',
+        label: this.translate.instant('users.ban.applyAction'),
+        icon: 'pi pi-ban',
+        actionId: 'applyBan',
       },
       {
-        label: this.translate.instant('users.unblock'),
+        label: this.translate.instant('users.ban.removeAction'),
         icon: 'pi pi-unlock',
-        disabled: !user.blocked,
-        actionId: 'unblock',
+        disabled: !hasBan,
+        actionId: 'removeBan',
       },
       {
         label: this.translate.instant('users.details'),
@@ -78,11 +80,11 @@ export class Users implements OnInit {
 
   onRowAction(user: User, actionId: string): void {
     switch (actionId) {
-      case 'block':
-        this.updateUserBlockStatus(user, true);
+      case 'applyBan':
+        this.applyBanDialog.showDialog(user);
         break;
-      case 'unblock':
-        this.updateUserBlockStatus(user, false);
+      case 'removeBan':
+        this.removeUserBan(user);
         break;
       case 'details':
         this.detailsDialog.showDialog(user.id);
@@ -90,9 +92,12 @@ export class Users implements OnInit {
     }
   }
 
-  private updateUserBlockStatus(user: User, status: boolean): void {
+  private removeUserBan(user: User): void {
     this.userService
-      .updateUserBlockStatus(user.id.toString(), status)
+      .updateUserBan(user.id.toString(), {
+        banType: null,
+        banExpiresAt: null,
+      })
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe();
   }

--- a/frontend/src/app/core/services/user-api-service.ts
+++ b/frontend/src/app/core/services/user-api-service.ts
@@ -12,7 +12,7 @@ import {
   switchMap,
 } from 'rxjs';
 import { UserStore } from '../store/user.store';
-import { Paginated, TableLoadParams, User } from '../models';
+import { Paginated, TableLoadParams, User, UserBanUpdate } from '../models';
 import { ToastService } from './toast-service';
 import { tableLoadParamsToStrapiQuery } from '../utils/table-load-params-to-query';
 import { TranslateService } from '@ngx-translate/core';
@@ -118,14 +118,14 @@ export class UserApiService extends ApiService {
     return this.get<User>(`users/${id}?populate=role`);
   }
 
-  updateUserBlockStatus(userId: string, blocked: boolean): Observable<User> {
-    return this.put<User>(`users/${userId}`, { blocked }).pipe(
+  updateUserBan(userId: string, ban: UserBanUpdate): Observable<User> {
+    return this.put<User>(`users/${userId}`, ban).pipe(
       tap(() => {
-        this.toastService.successToast(
-          this.translate.instant(
-            blocked ? 'user.userBlocked' : 'user.userUnblocked',
-          ),
-        );
+        const messageKey =
+          ban.banType == null
+            ? 'user.userBanRemoved'
+            : 'user.userBanApplied';
+        this.toastService.successToast(this.translate.instant(messageKey));
       }),
       switchMap((user) => {
         const params = this.userStore.users().lastLoadParams;
@@ -134,7 +134,7 @@ export class UserApiService extends ApiService {
       catchError((error) => {
         const msg =
           error.error?.error?.message ||
-          this.translate.instant('user.updateBlockStatusError');
+          this.translate.instant('user.updateBanError');
         this.toastService.errorToast(msg);
         return throwError(() => new Error(msg));
       }),

--- a/frontend/src/assets/i18n/en.json
+++ b/frontend/src/assets/i18n/en.json
@@ -17,7 +17,10 @@
     "usersFetchError": "Failed to fetch users",
     "userBlocked": "User blocked successfully",
     "userUnblocked": "User unblocked successfully",
-    "updateBlockStatusError": "Failed to update user block status"
+    "updateBlockStatusError": "Failed to update user block status",
+    "userBanApplied": "Sanction applied successfully",
+    "userBanRemoved": "Sanction removed successfully",
+    "updateBanError": "Failed to update user sanction"
   },
   "upload": {
     "success": "Avatar uploaded successfully",
@@ -97,6 +100,7 @@
     "notConfirmed": "Not Confirmed",
     "blocked": "Blocked",
     "active": "Active",
+    "banStatus": "Sanction",
     "editProfile": "Edit Profile",
     "changeAvatar": "Change avatar",
     "changePassword": "Change password",
@@ -131,7 +135,30 @@
     "lastName": "Last Name",
     "confirmed": "Confirmed",
     "blocked": "Blocked",
-    "createdAt": "Created At"
+    "createdAt": "Created At",
+    "ban": {
+      "title": "Apply sanction",
+      "targetUser": "User",
+      "typeLabel": "Sanction type",
+      "durationLabel": "Duration",
+      "apply": "Apply",
+      "applyAction": "Apply sanction",
+      "removeAction": "Remove sanction",
+      "status": "Sanction",
+      "expiresAt": "Expires at",
+      "type": {
+        "active": "Active",
+        "shadow": "Shadowban",
+        "time": "Temporary ban",
+        "perm": "Permanent ban"
+      },
+      "duration": {
+        "5m": "5 minutes",
+        "1h": "1 hour",
+        "7d": "7 days",
+        "30d": "30 days"
+      }
+    }
   },
   "post": {
     "addComment": "Add comment",

--- a/frontend/src/assets/i18n/pl.json
+++ b/frontend/src/assets/i18n/pl.json
@@ -17,7 +17,10 @@
     "usersFetchError": "Nie udało się pobrać użytkowników",
     "userBlocked": "Użytkownik zablokowany pomyślnie",
     "userUnblocked": "Użytkownik odblokowany pomyślnie",
-    "updateBlockStatusError": "Nie udało się zaktualizować statusu blokady"
+    "updateBlockStatusError": "Nie udało się zaktualizować statusu blokady",
+    "userBanApplied": "Sankcja nałożona pomyślnie",
+    "userBanRemoved": "Sankcja usunięta pomyślnie",
+    "updateBanError": "Nie udało się zaktualizować sankcji użytkownika"
   },
   "upload": {
     "success": "Avatar przesłany pomyślnie",
@@ -97,6 +100,7 @@
     "notConfirmed": "Niepotwierdzony",
     "blocked": "Zablokowany",
     "active": "Aktywny",
+    "banStatus": "Sankcja",
     "editProfile": "Edytuj profil",
     "changeAvatar": "Zmień avatar",
     "changePassword": "Zmień hasło",
@@ -132,7 +136,30 @@
     "confirmed": "Potwierdzony",
     "notConfirmed": "Niepotwierdzony",
     "blocked": "Zablokowany",
-    "createdAt": "Data utworzenia"
+    "createdAt": "Data utworzenia",
+    "ban": {
+      "title": "Nałóż sankcję",
+      "targetUser": "Użytkownik",
+      "typeLabel": "Typ sankcji",
+      "durationLabel": "Czas trwania",
+      "apply": "Nałóż",
+      "applyAction": "Nałóż sankcję",
+      "removeAction": "Usuń sankcję",
+      "status": "Sankcja",
+      "expiresAt": "Wygasa",
+      "type": {
+        "active": "Aktywny",
+        "shadow": "Shadowban",
+        "time": "Ban czasowy",
+        "perm": "Ban permanentny"
+      },
+      "duration": {
+        "5m": "5 minut",
+        "1h": "1 godzina",
+        "7d": "7 dni",
+        "30d": "30 dni"
+      }
+    }
   },
   "post": {
     "addComment": "Dodaj komentarz",

--- a/strapi/src/api/post/controllers/post.ts
+++ b/strapi/src/api/post/controllers/post.ts
@@ -3,5 +3,105 @@
  */
 
 import { factories } from '@strapi/strapi';
+import { USER_MODEL_UID } from '../../../utils/user-ban';
 
-export default factories.createCoreController('api::post.post');
+type PostAuthor = {
+  id?: number;
+  banType?: string | null;
+};
+
+type PostEntity = {
+  author?: PostAuthor | number | null;
+};
+
+function viewerIsShadowbanned(viewer: { banType?: string | null } | undefined): boolean {
+  return viewer?.banType === 'shadow';
+}
+
+function applyShadowbanAuthorFilter(
+  ctx: { state: { user?: { banType?: string | null } }; query?: Record<string, unknown> },
+) {
+  const viewer = ctx.state.user;
+  if (viewerIsShadowbanned(viewer)) {
+    return;
+  }
+
+  const existingFilters = (ctx.query?.filters ?? {}) as Record<string, unknown>;
+  const existingAuthorFilter =
+    typeof existingFilters.author === 'object' && existingFilters.author !== null
+      ? (existingFilters.author as Record<string, unknown>)
+      : {};
+
+  ctx.query = {
+    ...ctx.query,
+    filters: {
+      ...existingFilters,
+      author: {
+        ...existingAuthorFilter,
+        $or: [
+          { banType: { $null: true } },
+          { banType: { $ne: 'shadow' } },
+        ],
+      },
+    },
+  };
+}
+
+async function resolvePostAuthor(
+  strapi: { db: { query: Function } },
+  post: PostEntity,
+): Promise<PostAuthor | null> {
+  const author = post.author;
+
+  if (author && typeof author === 'object') {
+    return author;
+  }
+
+  if (!author) {
+    return null;
+  }
+
+  return strapi.db.query(USER_MODEL_UID).findOne({
+    where: { id: author },
+    select: ['id', 'banType'],
+  });
+}
+
+function isPostHiddenByShadowban(
+  author: PostAuthor | null,
+  viewer: { id?: number; banType?: string | null } | undefined,
+): boolean {
+  if (!author || author.banType !== 'shadow') {
+    return false;
+  }
+
+  if (viewerIsShadowbanned(viewer)) {
+    return false;
+  }
+
+  return !viewer?.id || viewer.id !== author.id;
+}
+
+export default factories.createCoreController('api::post.post', ({ strapi }) => ({
+  async find(ctx) {
+    applyShadowbanAuthorFilter(ctx);
+    return super.find(ctx);
+  },
+
+  async findOne(ctx) {
+    const response = await super.findOne(ctx);
+    const post = response?.data as PostEntity | undefined;
+
+    if (!post) {
+      return response;
+    }
+
+    const author = await resolvePostAuthor(strapi, post);
+
+    if (isPostHiddenByShadowban(author, ctx.state.user)) {
+      return ctx.notFound();
+    }
+
+    return response;
+  },
+}));

--- a/strapi/src/extensions/users-permissions/content-types/user/schema.json
+++ b/strapi/src/extensions/users-permissions/content-types/user/schema.json
@@ -59,6 +59,13 @@
       "default": false,
       "configurable": false
     },
+    "banType": {
+      "type": "enumeration",
+      "enum": ["shadow", "time", "perm"]
+    },
+    "banExpiresAt": {
+      "type": "datetime"
+    },
     "role": {
       "type": "relation",
       "relation": "manyToOne",

--- a/strapi/src/extensions/users-permissions/strapi-server.ts
+++ b/strapi/src/extensions/users-permissions/strapi-server.ts
@@ -1,8 +1,60 @@
-const USER_MODEL_UID = "plugin::users-permissions.user";
+import {
+  clearExpiredTimeBanIfNeeded,
+  normalizeBanFields,
+  USER_MODEL_UID,
+} from '../../utils/user-ban';
+
+const ALLOWED_UPDATE_ME_FIELDS = [
+  'firstName',
+  'lastName',
+  'aboutMe',
+  'birthDate',
+] as const;
+
+function pickAllowedUpdateMeFields(
+  body: Record<string, unknown>,
+): Record<string, unknown> {
+  return ALLOWED_UPDATE_ME_FIELDS.reduce<Record<string, unknown>>((acc, key) => {
+    if (key in body) {
+      acc[key] = body[key];
+    }
+    return acc;
+  }, {});
+}
+
+async function findUserByIdentifier(identifier: string) {
+  return strapi.db.query(USER_MODEL_UID).findOne({
+    where: {
+      $or: [{ email: identifier.toLowerCase() }, { username: identifier }],
+    },
+  });
+}
 
 export default (plugin) => {
   plugin.controllers = plugin.controllers || {};
   plugin.controllers.user = plugin.controllers.user || {};
+  plugin.controllers.auth = plugin.controllers.auth || {};
+
+  const authController = plugin.controllers.auth;
+  const originalAuthCallback = authController.callback?.bind(authController);
+
+  if (originalAuthCallback) {
+    authController.callback = async (ctx) => {
+      const provider = ctx.params.provider || 'local';
+
+      if (provider === 'local') {
+        const identifier = ctx.request.body?.identifier;
+        if (identifier) {
+          const user = await findUserByIdentifier(identifier);
+          if (user) {
+            await clearExpiredTimeBanIfNeeded(strapi, user);
+          }
+        }
+      }
+
+      return originalAuthCallback(ctx);
+    };
+  }
 
   plugin.controllers.user.find = async (ctx) => {
     await strapi.contentAPI.validate.query(ctx.query, strapi.getModel(USER_MODEL_UID), {
@@ -55,6 +107,46 @@ export default (plugin) => {
     };
   };
 
+  const originalUserMe = plugin.controllers.user.me?.bind(plugin.controllers.user);
+
+  if (originalUserMe) {
+    plugin.controllers.user.me = async (ctx) => {
+      const user = ctx.state.user;
+      if (user) {
+        const cleared = await clearExpiredTimeBanIfNeeded(strapi, user);
+        if (cleared) {
+          ctx.state.user = await strapi.db.query(USER_MODEL_UID).findOne({
+            where: { id: user.id },
+            populate: ['role'],
+          });
+        }
+      }
+
+      return originalUserMe(ctx);
+    };
+  }
+
+  const originalUserUpdate = plugin.controllers.user.update?.bind(
+    plugin.controllers.user,
+  );
+
+  if (originalUserUpdate) {
+    plugin.controllers.user.update = async (ctx) => {
+      const data = ctx.request.body as Record<string, unknown> | undefined;
+      if (data && ('banType' in data || 'banExpiresAt' in data || 'blocked' in data)) {
+        try {
+          normalizeBanFields(data);
+        } catch (error) {
+          const message =
+            error instanceof Error ? error.message : 'Invalid ban configuration';
+          return ctx.badRequest(message);
+        }
+      }
+
+      return originalUserUpdate(ctx);
+    };
+  }
+
   plugin.controllers.user.updateMe = async (ctx) => {
     try {
       const user = ctx.state.user;
@@ -62,10 +154,12 @@ export default (plugin) => {
         return ctx.unauthorized("You must be logged in to update your profile.");
       }
 
-      const data = ctx.request.body;
+      const data = pickAllowedUpdateMeFields(
+        (ctx.request.body ?? {}) as Record<string, unknown>,
+      );
 
       const updatedUser = await strapi
-        .documents("plugin::users-permissions.user")
+        .documents(USER_MODEL_UID)
         .update({
           documentId: user.documentId,
           data,

--- a/strapi/src/index.ts
+++ b/strapi/src/index.ts
@@ -1,4 +1,52 @@
 import type { Core } from '@strapi/strapi';
+import {
+  clearAllExpiredTimeBans,
+  clearExpiredTimeBanIfNeeded,
+  normalizeBanFields,
+  USER_MODEL_UID,
+} from './utils/user-ban';
+
+async function migrateBanTypes(strapi: Core.Strapi) {
+  const legacyNoneUsers = await strapi.db.query(USER_MODEL_UID).findMany({
+    where: { banType: 'none' },
+  });
+
+  for (const user of legacyNoneUsers) {
+    await strapi.documents(USER_MODEL_UID).update({
+      documentId: user.documentId,
+      data: {
+        banType: null,
+        banExpiresAt: null,
+        blocked: false,
+      },
+    });
+  }
+
+  if (legacyNoneUsers.length > 0) {
+    console.log(`Cleared legacy banType=none for ${legacyNoneUsers.length} user(s)`);
+  }
+
+  const blockedUsers = await strapi.db.query(USER_MODEL_UID).findMany({
+    where: {
+      blocked: true,
+      $or: [{ banType: { $null: true } }, { banType: 'none' }],
+    },
+  });
+
+  for (const user of blockedUsers) {
+    await strapi.documents(USER_MODEL_UID).update({
+      documentId: user.documentId,
+      data: {
+        banType: 'perm',
+        blocked: true,
+      },
+    });
+  }
+
+  if (blockedUsers.length > 0) {
+    console.log(`Migrated ${blockedUsers.length} blocked user(s) to banType=perm`);
+  }
+}
 
 async function setupRolePermissions(roleType: string, permissions: string[]) {
   const role = await strapi.db.query('plugin::users-permissions.role').findOne({
@@ -130,6 +178,23 @@ export default {
    */
   register({ strapi }: { strapi: Core.Strapi }) {
     strapi.documents.use(async (context, next) => {
+      if (context.uid === USER_MODEL_UID && context.action === 'update') {
+        const data = context.params?.data as Record<string, unknown> | undefined;
+        if (data) {
+          try {
+            normalizeBanFields(data);
+          } catch (error) {
+            const message =
+              error instanceof Error ? error.message : 'Invalid ban configuration';
+            throw new Error(message);
+          }
+        }
+      }
+
+      return next();
+    });
+
+    strapi.documents.use(async (context, next) => {
       if (context.uid !== 'api::post.post') return next();
       const isCreate = context.action === 'create';
       const isDelete = context.action === 'delete';
@@ -217,7 +282,21 @@ export default {
    * run jobs, or perform some special logic.
    */
   async bootstrap({ strapi }: { strapi: Core.Strapi }) {
-    // Setup default roles and permissions (Should use environment - DEV only, impossible to have more than 1 env variable with free Strapi Cloud)
+    await migrateBanTypes(strapi);
     await setupDefaultRolesAndPermissions();
+
+    const cronTask = async () => {
+      try {
+        const cleared = await clearAllExpiredTimeBans(strapi);
+        if (cleared > 0) {
+          strapi.log.info(`Cleared ${cleared} expired time ban(s)`);
+        }
+      } catch (error) {
+        strapi.log.warn('Failed to clear expired time bans', error);
+      }
+    };
+
+    cronTask();
+    setInterval(cronTask, 60 * 1000);
   },
 };

--- a/strapi/src/utils/user-ban.ts
+++ b/strapi/src/utils/user-ban.ts
@@ -1,0 +1,133 @@
+export const USER_BAN_TYPES = ['shadow', 'time', 'perm'] as const;
+export type UserBanType = (typeof USER_BAN_TYPES)[number];
+
+export const USER_MODEL_UID = 'plugin::users-permissions.user';
+
+export function hasActiveBan(banType: string | null | undefined): boolean {
+  return !!banType && USER_BAN_TYPES.includes(banType as UserBanType);
+}
+
+export function isTimeBanActive(
+  banType: string | null | undefined,
+  banExpiresAt: string | Date | null | undefined,
+  now: Date = new Date(),
+): boolean {
+  if (banType !== 'time' || !banExpiresAt) {
+    return false;
+  }
+  return new Date(banExpiresAt).getTime() > now.getTime();
+}
+
+export function computeBlockedFromBan(
+  banType: string | null | undefined,
+  banExpiresAt: string | Date | null | undefined,
+  now: Date = new Date(),
+): boolean {
+  if (banType === 'perm') {
+    return true;
+  }
+  if (banType === 'time') {
+    return isTimeBanActive(banType, banExpiresAt, now);
+  }
+  return false;
+}
+
+export function normalizeBanFields(
+  data: Record<string, unknown>,
+  now: Date = new Date(),
+): void {
+  if (!('banType' in data) && !('banExpiresAt' in data) && !('blocked' in data)) {
+    return;
+  }
+
+  const rawBanType = data.banType as string | null | undefined;
+
+  if (
+    rawBanType === null ||
+    rawBanType === undefined ||
+    rawBanType === '' ||
+    rawBanType === 'none'
+  ) {
+    data.banType = null;
+    data.banExpiresAt = null;
+    data.blocked = false;
+    return;
+  }
+
+  if (!USER_BAN_TYPES.includes(rawBanType as UserBanType)) {
+    throw new Error('Invalid ban type');
+  }
+
+  if (rawBanType === 'time') {
+    if (!data.banExpiresAt) {
+      throw new Error('banExpiresAt is required for time bans');
+    }
+    if (new Date(data.banExpiresAt as string).getTime() <= now.getTime()) {
+      throw new Error('banExpiresAt must be in the future');
+    }
+  } else {
+    data.banExpiresAt = null;
+  }
+
+  data.banType = rawBanType;
+  data.blocked = computeBlockedFromBan(
+    rawBanType,
+    data.banExpiresAt as string | Date | null | undefined,
+    now,
+  );
+}
+
+export function isExpiredTimeBan(
+  banType: string | null | undefined,
+  banExpiresAt: string | Date | null | undefined,
+  now: Date = new Date(),
+): boolean {
+  return (
+    banType === 'time' &&
+    !!banExpiresAt &&
+    new Date(banExpiresAt).getTime() <= now.getTime()
+  );
+}
+
+export async function clearExpiredTimeBanIfNeeded(
+  strapi: { db: { query: Function }; documents: Function },
+  user: {
+    id: number;
+    documentId: string;
+    banType?: string | null;
+    banExpiresAt?: string | Date | null;
+  },
+): Promise<boolean> {
+  if (!isExpiredTimeBan(user.banType, user.banExpiresAt)) {
+    return false;
+  }
+
+  await strapi.documents(USER_MODEL_UID).update({
+    documentId: user.documentId,
+    data: {
+      banType: null,
+      banExpiresAt: null,
+      blocked: false,
+    },
+  });
+
+  return true;
+}
+
+export async function clearAllExpiredTimeBans(
+  strapi: { db: { query: Function }; documents: Function },
+): Promise<number> {
+  const now = new Date();
+  const users = await strapi.db.query(USER_MODEL_UID).findMany({
+    where: {
+      banType: 'time',
+      banExpiresAt: { $lte: now },
+    },
+  });
+
+  for (const user of users) {
+    await clearExpiredTimeBanIfNeeded(strapi, user);
+  }
+
+  return users.length;
+}

--- a/strapi/types/generated/contentTypes.d.ts
+++ b/strapi/types/generated/contentTypes.d.ts
@@ -998,6 +998,8 @@ export interface PluginUsersPermissionsUser
         maxLength: 255;
       }>;
     avatar: Schema.Attribute.Media<'images' | 'files'>;
+    banExpiresAt: Schema.Attribute.DateTime;
+    banType: Schema.Attribute.Enumeration<['shadow', 'time', 'perm']>;
     birthDate: Schema.Attribute.DateTime;
     blocked: Schema.Attribute.Boolean & Schema.Attribute.DefaultTo<false>;
     confirmationToken: Schema.Attribute.String & Schema.Attribute.Private;


### PR DESCRIPTION
- Enhanced input field component to include a select type for ban options.
- Updated user profile and users page to display ban status and expiration.
- Introduced dialogs for applying and removing bans, with corresponding UI updates.
- Added translations for ban-related terms in English and Polish.
- Implemented backend logic for handling ban migrations and validations.